### PR TITLE
fix: Resolve ReferenceError: document is not defined during SSR

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,13 +1,23 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import { ContactMeForm } from '@/components/page-ui/ContactMe';
-import { ExperienceSection } from '@/components/page-ui/ExperienceSection';
+// import { ExperienceSection } from '@/components/page-ui/ExperienceSection'; // Static import removed
 import { LandingPage } from '@/components/page-ui/LandingPage';
 import { ProjectsSection } from '@/components/page-ui/ProjectsSection';
 import { SkillsSection } from '@/components/page-ui/SkillsSection';
 import { AboutMeSection } from '@/components/page-ui/AboutMeSection';
 
 export const runtime = "edge";
+
+// Dynamically import ExperienceSection
+const ExperienceSection = dynamic(() => 
+    import('@/components/page-ui/ExperienceSection').then(mod => mod.ExperienceSection), 
+    { 
+        ssr: false, 
+        loading: () => <p>Loading experience...</p> 
+    }
+);
 
 export default function Home() {
     return (

--- a/src/components/page-ui/LandingPage.tsx
+++ b/src/components/page-ui/LandingPage.tsx
@@ -33,15 +33,6 @@ const words1 = [
         className: 'text-red-500 dark:text-red-500'
     }
 ];
-const checkForCanvas = setInterval(() => {
-    const canvas = document.querySelector('canvas');
-    if(canvas) {
-        canvasDots();
-      console.log("Canvas found:", canvas);
-      // Perform operations with the canvas here
-      clearInterval(checkForCanvas); // Stop checking once the canvas is found
-    }
-  }, 100);
 
 export function LandingPage() {
     
@@ -54,6 +45,47 @@ export function LandingPage() {
 
         return () => clearTimeout(timer); // Clean up the timer
     }, []);
+
+    useEffect(() => {
+        // Ensure this only runs on the client side
+        if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+            let intervalId: NodeJS.Timeout | null = null;
+
+            const initCanvas = () => {
+                const canvasElement = document.querySelector('canvas.canvas-2');
+                if (canvasElement) {
+                    canvasDots();
+                    if (intervalId) {
+                        clearInterval(intervalId);
+                        intervalId = null; 
+                    }
+                }
+            };
+
+            // Attempt to initialize immediately
+            initCanvas();
+
+            // If canvas is not found, set an interval to check for it
+            if (!document.querySelector('canvas.canvas-2')) {
+                intervalId = setInterval(initCanvas, 100);
+            }
+
+            return () => {
+                if (intervalId) {
+                    clearInterval(intervalId);
+                }
+                // Placeholder for canvasDots cleanup, if it becomes available
+                // e.g., if canvasDots returned a cleanup function:
+                // if (typeof canvasDotsCleanup === 'function') {
+                //     canvasDotsCleanup();
+                // }
+                // Or manual cleanup if heroCanvas.js doesn't provide one:
+                // window.onmousemove = null;
+                // window.onresize = null;
+                // Potentially clear any interval set by canvasDots itself if possible
+            };
+        }
+    }, []); // Empty dependency array ensures it runs once on mount
 
     return (
         <div

--- a/src/components/page-ui/Navbar.tsx
+++ b/src/components/page-ui/Navbar.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { GitHubLogoIcon, InstagramLogoIcon, LinkBreak2Icon, LinkNone2Icon, LinkedInLogoIcon, TwitterLogoIcon, VercelLogoIcon } from '@radix-ui/react-icons';
 import React, { useState } from 'react';
+import dynamic from 'next/dynamic';
 
 import { ModeToggle } from '@/components/page-ui/ModeToggle';
 import { HoveredLink, Menu, MenuItem } from '@/components/ui/navbar-menu';
@@ -8,15 +9,8 @@ import { cn } from '@/lib/utils';
 import { Globe, Globe2, Globe2Icon, GlobeIcon, GlobeLock, Link2Icon, LucideGlobe, LucideGlobe2, Shield, ShieldEllipsisIcon, ShieldIcon } from 'lucide-react';
 import { FaGlobe } from 'react-icons/fa';
 
-export function Navbar() {
-    return (
-        <div className="relative flex w-full items-center justify-center">
-            <NavbarComponent className="top-2" />
-        </div>
-    );
-}
-
-function NavbarComponent({ className }: { className?: string }) {
+// Define NavbarComponent as a function expression assignable to a const
+const NavbarComponent = ({ className }: { className?: string }) => {
     const [active, setActive] = useState<string | null>(null);
     return (
         <div className={cn('fixed top-10 inset-x-0 max-w-2xl mx-auto z-50', className)}>
@@ -50,6 +44,19 @@ function NavbarComponent({ className }: { className?: string }) {
                 </MenuItem>
                 <ModeToggle />
             </Menu>
+        </div>
+    );
+};
+
+const ClientOnlyNavbarComponent = dynamic(() => Promise.resolve(NavbarComponent), {
+    ssr: false,
+    loading: () => <div style={{ height: '64px' }} className="top-2 fixed inset-x-0 max-w-2xl mx-auto z-50"></div>, // Placeholder for navbar height (approx 4rem or 64px for top-10 + padding)
+});
+
+export function Navbar() {
+    return (
+        <div className="relative flex w-full items-center justify-center">
+            <ClientOnlyNavbarComponent className="top-2" />
         </div>
     );
 }


### PR DESCRIPTION
The application was encountering a `ReferenceError: document is not defined` during server-side rendering (SSR), causing the Node.js process to exit. This typically occurs when client-side browser APIs like `document` or `window` are accessed in a Node.js environment.

This commit addresses the issue through the following changes:

1.  **Refactor `LandingPage.tsx` Canvas Animation:**
    - Moved the canvas initialization logic (which used `document.querySelector` and a `setInterval` at the module level) into a `useEffect` hook.
    - This ensures the canvas animation code, including the `canvasDots()` function, only runs on the client-side after component mounting.

2.  **Dynamically Import `NavbarComponent`:**
    - The `NavbarComponent` (within `src/components/page-ui/Navbar.tsx`), which uses `framer-motion` for its menu, is now dynamically imported with `ssr: false`. This prevents potential `document` access from `framer-motion`'s popover/menu logic during SSR.

3.  **Dynamically Import `ExperienceSection`:**
    - The `ExperienceSection` component (in `src/app/(home)/page.tsx`), which uses `LinkPreview` (`@radix-ui/react-hover-card`), is now dynamically imported with `ssr: false`. This prevents potential `document` access from Radix UI's HoverCard component (which might include "DismissableLayer" or scroll-locking behavior) during SSR.
